### PR TITLE
update Dockerfile to new aspen version 4.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM --platform=linux/amd64 almalinux:9
+FROM --platform=linux/amd64 almalinux:9.5
 RUN yum install -y epel-release  # extra packages (netcdf etc...)
 RUN yum install -y boost-regex boost-filesystem xerces-c boost-program-options netcdf netcdf-cxx4  # dependencies
 RUN mkdir /src
 WORKDIR /src
-RUN curl "https://archive.eol.ucar.edu/docs/software/aspen/AspenV4.0.2_AlmaLinux9.4_x86_64.tar.gz" | tar -xzf -
-WORKDIR /src/AspenV4.0.2_AlmaLinux9.4_x86_64/bin/
+RUN curl "https://archive.eol.ucar.edu/docs/software/aspen/AspenV4.0.4_AlmaLinux9.5_x86_64.tar.gz" | tar -xzf -
+WORKDIR /src/AspenV4.0.4_AlmaLinux9.5_x86_64/bin/
 ENTRYPOINT ["./Aspen-QC"]
 CMD ["-i", "-e"]


### PR DESCRIPTION
A new aspen version 4.0.4 is available which we can add to the repository and build an image for. Changes according to [NCAR](https://www.eol.ucar.edu/software/aspen) are:

- Add check to remove RH values that do not have an associated temperature at the end of QC processing
- Remove logic to retain the last point in each data series, even if it failed CRC check
- Add buttons to set Skew-T display bounds to preset values for common aircraft altitudes
- Add minimum equilibration time threshold of 6 seconds for temperature and RH equilibration calculations
- Add configuration set name to Summary tab
- Update autosaved WMO text (in addition to the WMO tab display) when the user makes modifications in the Comm tab
- Add a User Modifications section to the Summary tab to record manual QC changes during processing
  - In Main tab, log ignored or overridden launch parameters, changes to dropsonde hit surface or surface altitude unknown checkboxes, surface altitude or pressure overrides, heights set to missing, and end of drop time overrides
  - In Raw tab, log changes to end of drop time, and points flagged as keep or ignore
  - In Comm tab, log the sonde environment set by the user (if present)
  - The user modifications text section is also added to global attributes in netCDF and CSV output, with one caveat: due to Aspen architecture limitations, netCDF and CSV data will not be updated when the user modifies the sonde environment in the Comm tab, unless the user manually recomputes