### PR TITLE
Bump Aspen to version 4.0.5 to support minisondes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM --platform=linux/amd64 almalinux:9.5
+ARG ALMALINUX_VER=9.6
+FROM --platform=linux/amd64 almalinux:${ALMALINUX_VER}
 RUN yum install -y epel-release  # extra packages (netcdf etc...)
 RUN yum install -y boost-regex boost-filesystem xerces-c boost-program-options netcdf netcdf-cxx4  # dependencies
 RUN mkdir /src
 WORKDIR /src
-RUN curl "https://archive.eol.ucar.edu/docs/software/aspen/AspenV4.0.4_AlmaLinux9.5_x86_64.tar.gz" | tar -xzf -
-WORKDIR /src/AspenV4.0.4_AlmaLinux9.5_x86_64/bin/
+ARG ALMALINUX_VER=9.6
+ARG ASPEN_VER=4.0.5
+RUN curl "https://archive.eol.ucar.edu/docs/software/aspen/AspenV${ASPEN_VER}_AlmaLinux${ALMALINUX_VER}_x86_64.tar.gz" | tar -xzf -
+WORKDIR /src/AspenV${ASPEN_VER}_AlmaLinux${ALMALINUX_VER}_x86_64/bin/
 ENTRYPOINT ["./Aspen-QC"]
 CMD ["-i", "-e"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN yum install -y epel-release  # extra packages (netcdf etc...)
 RUN yum install -y boost-regex boost-filesystem xerces-c boost-program-options netcdf netcdf-cxx4  # dependencies
 RUN mkdir /src
 WORKDIR /src
-ARG ALMALINUX_VER=9.6
+ARG ALMALINUX_VER
 ARG ASPEN_VER=4.0.5
 RUN curl "https://archive.eol.ucar.edu/docs/software/aspen/AspenV${ASPEN_VER}_AlmaLinux${ALMALINUX_VER}_x86_64.tar.gz" | tar -xzf -
 WORKDIR /src/AspenV${ASPEN_VER}_AlmaLinux${ALMALINUX_VER}_x86_64/bin/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ In principle, the software can be run on a few operating systems.
 However, hosting the software in form of a docker image makes it independent from the operating system which is the purpose of this repository.
 
 The repository includes a `Dockerfile` and the respective GitHub workflows needed to generate the image and push it to the [GitHub container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
-Currently, there is only the [ASPEN version 4.0.2](https://www.eol.ucar.edu/software/aspen) (Jun 7, 2024) available.
+Up to [ASPEN version 4.0.5](https://www.eol.ucar.edu/software/aspen) (Jun 16, 2025) is available,
+which includes support for mini-dropsonde configs.
 Older as well as newer versions could also be added in a similar way and you can open an issue if you would like to have them or add them yourself.
 
 ## Usage
@@ -17,28 +18,33 @@ The simplest way would be to install `Docker Desktop` (on MacOS also possible vi
 The name of the image is `ghcr.io/atmdrops/aspenqc`.
 
 Run ASPEN and display the help statement:
+
 ```
 docker run --rm -i ghcr.io/atmdrops/aspenqc --help
 ```
 
 To process a single `Level_0` file (e.g. `D20240730_100114.1`)and write the output to stdout:
+
 ```
 cat D20240730_100114.1 | docker run --rm -i ghcr.io/atmdrops/aspenqc
 ```
 
 You can add a tag a the end to point to a specific version, e.g. `4.0.2` or `latest`.
 For an overview of available versions/tags, have a look [here](https://github.com/atmdrops/aspenqc/pkgs/container/aspenqc).
+
 ```
 cat D20240730_100114.1 | docker run --rm -i ghcr.io/atmdrops/aspenqc:4.0.2
 ```
 
 ### Generating a Level_1 netCDF files
+
 The idea of docker is that you can run software detached from you local operating system.
 Therefore, writing any generated output to your local disc is not straight forward, but possible via explicitly mounting a specified folder.
 For details have a look at docker’s documentation on [bind mounts](https://docs.docker.com/storage/bind-mounts/).
-TL;DR you need to specify a *source* directory (local) which the docker image can see and has access to and you also need to specify a *target*, which is the name of the source directory within the docker image.
+TL;DR you need to specify a _source_ directory (local) which the docker image can see and has access to and you also need to specify a _target_, which is the name of the source directory within the docker image.
 
 An example would be:
+
 ```
 docker run --rm --mount type=bind,source=path/to/dropsondes/data,target=/data ghcr.io/atmdrops/aspenqc -i /data/20240730/Level_0/D20240730_100114.1 -n /data/20240730/Level_1/D20240730_100114.1.nc
 ```


### PR DESCRIPTION
Bumping Aspen to 4.0.5 to support mini-dropsonde configs.

1. Updated Dockerfile to allow build args for alma linux version (ALMALINUX_VER) and aspenqc version (ASPEN_VER)
2. Default versions to ALMALINUX_VER=9.6 and ASPEN_VER=4.0.5 
3. README.md updated to reference 4.0.5 as well

I left the github workflow config alone.

By default 4.0.5 can be built like `docker build --rm --tag ghcr.io/atmdrops/aspenqc:4.0.5 -f Dockerfile .`

But the build-args support `docker build --rm --build-arg ASPEN_VER=4.0.5 --build-arg ALMALINUX_VER=9.6 --tag ghcr.io/atmdrops/aspenqc:4.0.5 -f Dockerfile .`, although the availability of the ASPEN version for specific AlmaLinux versions is dictated by what is available on https://www.eol.ucar.edu/software/aspen . (For instance, `docker build --rm --build-arg ASPEN_VER=4.0.5 --build-arg ALMALINUX_VER=9.5 --tag ghcr.io/atmdrops/aspenqc:4.0.5-9.5 -f Dockerfile .` doesn't work.)